### PR TITLE
运费调整与修复字段不存在的问题

### DIFF
--- a/api/custormerOrder.go
+++ b/api/custormerOrder.go
@@ -89,7 +89,7 @@ func ConfirmCustormerOrder(c *gin.Context) {
 	orderID := c.Param("id")
 
 	var data struct {
-		Freight float32 `json:"freight" binding:"required"`
+		Freight *float32 `json:"freight" binding:"required"`
 	}
 	err := c.ShouldBindJSON(&data)
 	if err != nil {
@@ -97,7 +97,7 @@ func ConfirmCustormerOrder(c *gin.Context) {
 		return
 	}
 
-	orderInfo, err := models.ConfirmCustormerOrder(orderID, data.Freight)
+	orderInfo, err := models.ConfirmCustormerOrder(orderID, *data.Freight)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, response.Error{Error: err.Error()})
 		return

--- a/api/purchaseOrder.go
+++ b/api/purchaseOrder.go
@@ -78,7 +78,7 @@ func ConfirmPurchaseOrder(c *gin.Context) {
 	orderID := c.Param("id")
 
 	var data struct {
-		Freight float32 `json:"freight" binding:"required"`
+		Freight *float32 `json:"freight" binding:"required"`
 	}
 	err := c.ShouldBindJSON(&data)
 	if err != nil {
@@ -86,7 +86,7 @@ func ConfirmPurchaseOrder(c *gin.Context) {
 		return
 	}
 
-	orderInfo, err := models.ConfirmPurchaseOrder(orderID, data.Freight)
+	orderInfo, err := models.ConfirmPurchaseOrder(orderID, *data.Freight)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, response.Error{Error: err.Error()})
 		return

--- a/models/custormerOrder.go
+++ b/models/custormerOrder.go
@@ -196,7 +196,7 @@ func ConfirmCustormerOrder(orderID string, freight float32) (*CustormerOrderInfo
 // CustormerOrderInfo 与客户端通信的订单信息
 type CustormerOrderInfo struct {
 	CustormerOrder
-	Goods []Commodity
+	Goods []Commodity `gorm:"-"`
 }
 
 // ListCustormerOrders 获取所有客户订单

--- a/models/purchaseOrder.go
+++ b/models/purchaseOrder.go
@@ -134,7 +134,7 @@ func ConfirmPurchaseOrder(orderID string, freight float32) (*PurchaseOrderInfo, 
 // PurchaseOrderInfo 订单信息
 type PurchaseOrderInfo struct {
 	PurchaseOrder
-	Goods []Commodity
+	Goods []Commodity `gorm:"-"`
 }
 
 // ListPurchaseOrders 所有订单


### PR DESCRIPTION
1. 修复2个invalid field found for struct XXX的问题
2. 允许运费传参可以为0
```
[error] invalid field found for struct github.com/Allenxuxu/mogutouERP/models.PurchaseOrderInfo's field Goods, need to define a valid foreign key for relations or it need to implement the Valuer/Scanner interface
[error] invalid field found for struct github.com/Allenxuxu/mogutouERP/models.CustormerOrderInfo's field Goods, need to define a valid foreign key for relations or it need to implement the Valuer/Scanner interface
```
